### PR TITLE
fix elif statement in searchDFS

### DIFF
--- a/lib/tiedie_util.py
+++ b/lib/tiedie_util.py
@@ -230,7 +230,7 @@ def searchDFS(source, action, discovered, linker_nodes, target_set, net, gene_st
 		action_this_target = None
 		if i_type == 1:
 			action_this_target = action
-		elif i_type == 2:
+		elif i_type == -1:
 			action_this_target = -action
 
 		# for transcriptional states: the expression activity is what we want to measure


### PR DESCRIPTION
classifyInteraction returns one of {-1, 0, 1}, but searchDFS was checking against {2, 0, 1}. This means negative interactions were never added to the set of discovered pathways.
Fixed so that searchDFS checks against {-1, 0, 1}.